### PR TITLE
2nd is also an ordinal

### DIFF
--- a/Google/Ordinal.yml
+++ b/Google/Ordinal.yml
@@ -4,4 +4,4 @@ link: 'https://developers.google.com/style/numbers'
 level: error
 nonword: true
 tokens:
-  - \d+(?:st|th|rd)
+  - \d+(?:st|nd|rd|th)

--- a/features/rules.feature
+++ b/features/rules.feature
@@ -61,9 +61,10 @@ Feature: Rules
     Then the output should contain exactly:
       """
       test.md:3:1:Google.Ordinal:Spell out all ordinal numbers ('1st') in text.
-      test.md:3:6:Google.Ordinal:Spell out all ordinal numbers ('5th') in text.
-      test.md:3:11:Google.Ordinal:Spell out all ordinal numbers ('12th') in text.
-      test.md:3:17:Google.Ordinal:Spell out all ordinal numbers ('43rd') in text.
+      test.md:3:6:Google.Ordinal:Spell out all ordinal numbers ('2nd') in text.
+      test.md:3:11:Google.Ordinal:Spell out all ordinal numbers ('5th') in text.
+      test.md:3:16:Google.Ordinal:Spell out all ordinal numbers ('12th') in text.
+      test.md:3:22:Google.Ordinal:Spell out all ordinal numbers ('43rd') in text.
       """
 
   Scenario: Date Formatting

--- a/fixtures/Numbers/test.md
+++ b/fixtures/Numbers/test.md
@@ -1,3 +1,3 @@
 Look at pages 3 – 5.
 
-1st, 5th, 12th, 43rd
+1st, 2nd, 5th, 12th, 43rd


### PR DESCRIPTION
The check for ordinals did not catch the use of "2nd", only "1st", "3rd", "4th", "5th" etc.

Also updated the order in `Ordinal.yml`