### PR TITLE
Flag missing Oxford comma for sentences with 'or'

### DIFF
--- a/Google/OxfordComma.yml
+++ b/Google/OxfordComma.yml
@@ -4,4 +4,4 @@ link: 'https://developers.google.com/style/commas'
 scope: sentence
 level: warning
 tokens:
-  - '(?:[^,]+,){1,}\s\w+\sand'
+  - '(?:[^,]+,){1,}\s\w+\s(?:and|or)'

--- a/features/rules.feature
+++ b/features/rules.feature
@@ -96,6 +96,7 @@ Feature: Rules
       test.md:25:24:Google.Quotes:Commas and periods go inside quotation marks.
       test.md:27:34:Google.Semicolons:Use semicolons judiciously.
       test.md:27:45:Google.Exclamation:Don't use exclamation points in text.
+      test.md:29:1:Google.OxfordComma:Use the Oxford comma in 'Apples, pears or bananas'.
       """
 
   Scenario: Foreign words

--- a/features/rules.feature
+++ b/features/rules.feature
@@ -96,7 +96,7 @@ Feature: Rules
       test.md:25:24:Google.Quotes:Commas and periods go inside quotation marks.
       test.md:27:34:Google.Semicolons:Use semicolons judiciously.
       test.md:27:45:Google.Exclamation:Don't use exclamation points in text.
-      test.md:29:1:Google.OxfordComma:Use the Oxford comma in 'Apples, pears or bananas'.
+      test.md:29:1:Google.OxfordComma:Use the Oxford comma in 'Apples, pears or'.
       """
 
   Scenario: Foreign words

--- a/fixtures/Punctuation/test.md
+++ b/fixtures/Punctuation/test.md
@@ -25,3 +25,5 @@ That's true (unless it's not).
 See the section titled "Care and feeding of the emu".
 
 The section’s title is too boring; change it!
+
+Apples, pears or bananas


### PR DESCRIPTION
The existing check caught `a, b and c`, but not `a, b or c`.
This is not in line with Googles rule:
> In a series of three or more items, use a comma before the final "and" or "or."