### PR TITLE
fix: accept `gRPC` in headings

### DIFF
--- a/Google/Headings.yml
+++ b/Google/Headings.yml
@@ -11,6 +11,7 @@ exceptions:
   - Cosmos
   - Docker
   - Emmet
+  - gRPC
   - I
   - Kubernetes
   - Linux

--- a/fixtures/Headings/test.md
+++ b/fixtures/Headings/test.md
@@ -7,3 +7,5 @@
 # Another one.
 
 # Accepting a JSON response
+
+# Using gRPC


### PR DESCRIPTION
Is this the right way of dealing with #7?

If so, I think there's a lot of exceptions that I think should be considered because of how often they can appear in headings.

Or is the expectation for this repo to be a starting point that folks can then extend on?
