### PR TITLE
Update the regex for ordinals

### DIFF
--- a/Google/Ordinal.yml
+++ b/Google/Ordinal.yml
@@ -4,4 +4,4 @@ link: 'https://developers.google.com/style/numbers'
 level: error
 nonword: true
 tokens:
-  - \d+(?:st|nd|rd|th)
+  - (?<!\S)\d(?:st|nd|rd|th)


### PR DESCRIPTION
The original regex triggers off things like 95th. I tested this using https://regexr.com/ and my local Vale. I'm definitely a regex newbie, so there may be a better way.

![image](https://user-images.githubusercontent.com/53799971/168652071-308d7c67-49a8-480e-b36c-88986fae8785.png)

