### PR TITLE
add "aka" rule

### DIFF
--- a/Google/WordList.yml
+++ b/Google/WordList.yml
@@ -25,6 +25,7 @@ swap:
   action bar: app bar
   admin: administrator
   Ajax: AJAX
+  (?i)a\.k\.a|aka: or|also known as
   Android device: Android-powered device
   android: Android
   API explorer: APIs Explorer


### PR DESCRIPTION
Add rule for flagging "aka" or "a.k.a" 

https://developers.google.com/style/word-list#aka