### PR TITLE
Fix to not match the space after `i.e.`

### DIFF
--- a/Google/Latin.yml
+++ b/Google/Latin.yml
@@ -7,5 +7,5 @@ nonword: true
 action:
   name: replace
 swap:
-  '\b(?:eg|e\.g\.)[\s,]': for example
-  '\b(?:ie|i\.e\.)[\s,]': that is
+  '\b(?:eg|e\.g\.)(?=[\s,;])': for example
+  '\b(?:ie|i\.e\.)(?=[\s,;])': that is


### PR DESCRIPTION
Test text: `Don't use i.e. or e.g.; instead, use that is or for example, respectively`
Current match: `i.e. `
After this fix, match: `i.e.` and `e.g.`