### PR TITLE
Updated rule for American Spelling

### DIFF
--- a/Google/Spelling.yml
+++ b/Google/Spelling.yml
@@ -6,4 +6,5 @@ level: warning
 tokens:
   - '(?:\w+)nised?'
   - 'colour'
+  - 'labour'
   - 'center'

--- a/Google/Spelling.yml
+++ b/Google/Spelling.yml
@@ -6,5 +6,4 @@ level: warning
 tokens:
   - '(?:\w+)nised?'
   - '(?:\w+)logue'
-  - '(?:\w+)tre'
   - '(?:\w+)our'

--- a/Google/Spelling.yml
+++ b/Google/Spelling.yml
@@ -7,4 +7,4 @@ tokens:
   - '(?:\w+)nised?'
   - 'colour'
   - 'labour'
-  - 'center'
+  - 'centre'

--- a/Google/Spelling.yml
+++ b/Google/Spelling.yml
@@ -5,5 +5,4 @@ ignorecase: true
 level: warning
 tokens:
   - '(?:\w+)nised?'
-  - '(?:\w+)logue'
-  - '(?:\w+)our'
+  - 'colour'

--- a/Google/Spelling.yml
+++ b/Google/Spelling.yml
@@ -6,3 +6,5 @@ level: warning
 tokens:
   - '(?:\w+)nised?'
   - '(?:\w+)logue'
+  - '(?:\w+)tre'
+  - '(?:\w+)our'

--- a/Google/Spelling.yml
+++ b/Google/Spelling.yml
@@ -6,3 +6,4 @@ level: warning
 tokens:
   - '(?:\w+)nised?'
   - 'colour'
+  - 'center'


### PR DESCRIPTION
Added rules to pick up words like `centre`, `theatre`, `colour`, `labour` etc.

Also, for the token that checks for `-logue`, I have questions. For example, I think both `catalogue` and `catalog` are acceptable for American English if I'm not mistaken? Or maybe if you can find any supporting evidence on `catalog` being preferred for American English to persuade me?? Lived in Canada and may be confused.
