### PR TITLE
Remove steward

### DIFF
--- a/Google/GenderBias.yml
+++ b/Google/GenderBias.yml
@@ -39,7 +39,6 @@ swap:
   repair(?:m[ae]n|wom[ae]n):   technician(s)
   sales(?:m[ae]n|wom[ae]n):    salesperson or sales people
   service(?:m[ae]n|wom[ae]n):  soldier(s)
-  steward(?:ess)?:             flight attendant
   tribes(?:m[ae]n|wom[ae]n):   tribe member(s)
   waitress:                    waiter
   woman doctor:                doctor


### PR DESCRIPTION
This looks wrong to me, it can't be an error since it's this word has polysemy.

<img width="499" alt="SCR-20240316-nzvj" src="https://github.com/errata-ai/Google/assets/3165635/9892d70d-4458-4b42-b6cc-516bd7643406">

https://www.merriam-webster.com/dictionary/steward