### PR TITLE
Fixes #38: Fix to ignore colons embracing emojis

### DIFF
--- a/Google/Colons.yml
+++ b/Google/Colons.yml
@@ -5,4 +5,4 @@ nonword: true
 level: warning
 scope: sentence
 tokens:
-  - ':\s[A-Z]'
+  - '(?<!:[^ ]+?):\s[A-Z]'


### PR DESCRIPTION
Use a negative reverse lookup to ignore the colons making up emoji tokens (e.g. `:thumbs-up:`).