### PR TITLE
Remove nonword option from FirstPerson.yml

### DIFF
--- a/Google/FirstPerson.yml
+++ b/Google/FirstPerson.yml
@@ -3,7 +3,6 @@ message: "Avoid first-person pronouns such as '%s'."
 link: 'https://developers.google.com/style/pronouns#personal-pronouns'
 ignorecase: true
 level: warning
-nonword: true
 tokens:
   - (?:^|\s)I\s
   - (?:^|\s)I,\s


### PR DESCRIPTION
I am not sure if this has any effect on anything else, but this property seems to cause issues with the underlines in extensions that use the language server, removing it fixes that.

If you feel it's needed, I'll try and find another solution.