### PR TITLE
Skip parentheses containing acronyms with three to five characters

### DIFF
--- a/Google/Parens.yml
+++ b/Google/Parens.yml
@@ -4,4 +4,4 @@ link: 'https://developers.google.com/style/parentheses'
 nonword: true
 level: suggestion
 tokens:
-  - '\(.+\)'
+  - '\((?![A-Z]{3,5}\b)([^)]+)\)'


### PR DESCRIPTION
Hi @jdkato, the current parentheses rule is too broad, it displays a vale suggestion for all use of parentheses. However, the [Acronym rule](https://github.com/errata-ai/Google/blob/6084433be646263c9eb3f3868ceb81d76ea2f313/Google/Acronyms.yml#L7) captures 3–5 uppercase abbreviations, and it isn't accounted for in the parentheses rule.

The unaccounted abbreviation limit has been resolved in this PR. Words with acronyms in a parentheses won't require a parentheses suggestion anymore since it adheres with the abbreviation and parentheses rules.

One example is `National Aeronautics and Space Administration (NASA)`.

