### PR TITLE
Fix OAuth 2.0 regex in the word list rule

### DIFF
--- a/Google/WordList.yml
+++ b/Google/WordList.yml
@@ -12,7 +12,7 @@ swap:
   "(?:e-mail|Email|E-mail)": email
   "(?:file ?path|path ?name)": path
   "(?:kill|terminate|abort)": stop|exit|cancel|end
-  "(?:OAuth ?2|Oauth)": OAuth 2.0
+  "(?i)\\bOauth\\b(?! 2\\.0)|\\bOauth2\\.0\\b|\\bOAuth ?2\\b(?!\\.0)": OAuth 2.0
   "(?:ok|Okay)": OK|okay
   "(?:WiFi|wifi)": Wi-Fi
   '[\.]+apk': APK


### PR DESCRIPTION
Hi @jdkato, the OAuth 2.0 regex in the word list rule isn't working. When you enter `OAuth 2.0` you still get a Vale warning.
This PR fixes it. The regex matches `OAuth2` and `OAuth 2`, but not `OAuth 2.0`. It's also case-insensitive, meaning it matches `oauth2` and more.